### PR TITLE
typoの修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ all: \
 	$(DATADIR)/domains.txt \
 	data/packages/finished.txt \
 	data/groups.txt \
-	data/title.csv
+	data/titles.csv
 
 clean:
 	rm data/packages/started.txt


### PR DESCRIPTION
`Makefile` 内の `all` ターゲットにて、 `data/title.csv` を `data/titles.csv` に修正しました。

現在のmainでは、 `make` 時エラーが発生します。

```shellsession
->>> make
mkdir -p data/2023/03/28
curl -s "https://catalog.data.metro.tokyo.lg.jp/api/3/action/resource_search?query=name:&order_by=last_modified" | jq . > data/2023/03/28/resource_list.json
cat data/2023/03/28/resource_list.json | jq -r '.result.results[] | [.id, .package_id, .url] | @csv' > data/2023/03/28/resource_url_list.csv
cat data/2023/03/28/resource_url_list.csv | cut -d ',' -f 2 | sort | uniq > data/2023/03/28/packages.txt
cat data/2023/03/28/resource_url_list.csv | cut -d ',' -f 3 | cut -d/ -f 3 | sort | uniq > data/2023/03/28/domains.txt
make: *** No rule to make target `data/title.csv', needed by `all'.  Stop.
```